### PR TITLE
Allow rotating piece counterclockwise with RMB.

### DIFF
--- a/src/piece.h
+++ b/src/piece.h
@@ -68,7 +68,7 @@ private slots:
 
 private:
 	void moveTo(const QPointF& new_pos);
-	void rotate();
+	void rotate(bool right);
 
 	Puzzle* m_puzzle;
 	QList<int> m_colors;
@@ -80,6 +80,7 @@ private:
 	Piece* m_swap_piece;
 	QPoint m_start_position;
 	bool m_clicked;
+	bool m_clicked_right;
 };
 
 #endif


### PR DESCRIPTION
Hi, cool game.
I added rotating back with RMB click.
Now you can e.g. click RMB once, instead of 5 times LMB.

BTW, I like it more with faster rotation, by setting:
`m_rotate_timer->setInterval(15);`
It was 40. What do you think about that? Swapping pieces is fast already.